### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
@@ -402,6 +402,11 @@ public class UpstreamRegistryService implements IExtensionRegistry {
     }
 
     public String getPublicKey(String publicId) {
+        if (!isValidPublicId(publicId)) {
+            logger.error("Invalid publicId: " + publicId);
+            throw new IllegalArgumentException("Invalid publicId format");
+        }
+
         var urlTemplate = urlConfigService.getUpstreamUrl() + "/api/public-key/{publicId}";
         var uriVariables = new HashMap<String, String>();
         uriVariables.put("publicId", publicId);
@@ -416,6 +421,11 @@ public class UpstreamRegistryService implements IExtensionRegistry {
 
             throw new NotFoundException();
         }
+    }
+
+    private boolean isValidPublicId(String publicId) {
+        // Validate that the publicId is a valid UUID
+        return publicId != null && publicId.matches("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
     }
 
     /**


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/openvsx/security/code-scanning/14](https://github.com/Dargon789/openvsx/security/code-scanning/14)

To fix the SSRF vulnerability, we need to validate the `publicId` parameter before using it in the `uriVariables` map. This can be achieved by ensuring that the `publicId` conforms to a specific format or matches a whitelist of allowed values. For example, if `publicId` is expected to be a UUID, we can validate it using a regular expression or a UUID parsing library.

The fix involves:
1. Adding validation logic for the `publicId` parameter in the `getPublicKey` method of `UpstreamRegistryService`.
2. Logging an error and throwing an exception if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add input validation to prevent server-side request forgery (SSRF) vulnerability in the public key retrieval method

New Features:
- Add UUID format validation for publicId before making upstream API requests

Bug Fixes:
- Implement validation for publicId parameter to prevent potential server-side request forgery